### PR TITLE
Add PDF, Markdown, and Text files

### DIFF
--- a/s3like/__init__.py
+++ b/s3like/__init__.py
@@ -62,6 +62,9 @@ def get_serializer(media_type):
         "MP3": Serializer("mp3"),
         "MP4": Serializer("mp4"),
         "HDF5": Serializer("h5"),
+        "PDF": Serializer("pdf"),
+        "Markdown": TextSerializer("md"),
+        "Text": TextSerializer("txt"),
     }[media_type]
 
 
@@ -70,7 +73,7 @@ class Output:
 
     title = fields.Str()
     media_type = fields.Str(
-        validate=validate.OneOf(choices=["bokeh", "table", "CSV", "PNG", "JPEG", "MP3", "MP4", "HDF5"])
+        validate=validate.OneOf(choices=["bokeh", "table", "CSV", "PNG", "JPEG", "MP3", "MP4", "HDF5", "PDF", "Markdown", "Text"])
     )
 
 

--- a/s3like/tests/test_s3like.py
+++ b/s3like/tests/test_s3like.py
@@ -98,6 +98,21 @@ def test_s3like():
                 "title": "HDF5 file",
                 "data": b"serialized numpy arrays and such\n"
             },
+            {
+                "media_type": "PDF",
+                "title": "PDF file",
+                "data": b"some pdf like data."
+            },
+            {
+                "media_type": "Markdown",
+                "title": "Markdown file",
+                "data": "**hello world**"
+            },
+            {
+                "media_type": "Text",
+                "title": "Text file",
+                "data": "text data"
+            },
         ],
     }
     task_id = uuid.uuid4()


### PR DESCRIPTION
This PR adds support for PDF, Markdown, and Text files. Note that data for PDF files should be passed to `s3like` as a byte string.

cc @andersonfrailey